### PR TITLE
Implement dynamic spectrogram normalization

### DIFF
--- a/packet_extractor.py
+++ b/packet_extractor.py
@@ -4,7 +4,7 @@ import matplotlib.pyplot as plt
 from matplotlib.widgets import RectangleSelector
 import tkinter as tk
 from tkinter import filedialog, ttk
-from utils import create_spectrogram, plot_spectrogram, get_sample_rate_from_mat
+from utils import create_spectrogram, plot_spectrogram, get_sample_rate_from_mat, normalize_spectrogram
 
 class PacketExtractor:
     def __init__(self):
@@ -68,12 +68,7 @@ class PacketExtractor:
         try:
             sample_rate = float(self.sample_rate_var.get()) * 1e6
             f, t, Sxx = create_spectrogram(self.signal, sample_rate)
-            
-            # נרמול הספקטוגרמה
-            Sxx_db = 10 * np.log10(np.abs(Sxx) + 1e-10)
-            Sxx_db = Sxx_db - np.max(Sxx_db)  # נרמול למקסימום 0 dB
-            vmin = max(-60, np.percentile(Sxx_db, 5))
-            vmax = np.percentile(Sxx_db, 99)
+            Sxx_db, vmin, vmax = normalize_spectrogram(Sxx)
             
             # יצירת חלון חדש לספקטוגרמה
             fig, ax = plt.subplots(figsize=(12, 6))

--- a/show_packets.py
+++ b/show_packets.py
@@ -2,6 +2,7 @@ import scipy.io as sio
 import numpy as np
 import matplotlib.pyplot as plt
 from scipy import signal
+from utils import normalize_spectrogram
 
 for i in range(1, 7):
     try:
@@ -10,8 +11,9 @@ for i in range(1, 7):
         print(f"פקטה {i} - ערכים ראשונים:", y[:10])
         print(f"פקטה {i} - סכום מוחלטים:", np.abs(y).sum())
         f, t, Sxx = signal.spectrogram(y, 44100)
+        Sxx_db, vmin, vmax = normalize_spectrogram(Sxx)
         plt.figure(figsize=(8, 4))
-        plt.pcolormesh(t, f, 10 * np.log10(Sxx + 1e-12))
+        plt.pcolormesh(t, f, Sxx_db, vmin=vmin, vmax=vmax)
         plt.title(f'ספקטוגרמה פקטה {i}')
         plt.ylabel('תדירות [Hz]')
         plt.xlabel('זמן [שניות]')

--- a/utils.py
+++ b/utils.py
@@ -55,11 +55,21 @@ def create_spectrogram(sig, sr, center_freq=0):
     Sxx = np.fft.fftshift(Sxx, axes=0)
     return freqs, times, Sxx
 
+def normalize_spectrogram(Sxx, low_percentile=5, high_percentile=99, max_dynamic_range=60):
+    """Normalize spectrogram values and compute display range.
+
+    Returns normalized Sxx in dB and suitable vmin/vmax for plotting."""
+    Sxx_db = 10 * np.log10(np.abs(Sxx) + 1e-10)
+    Sxx_db -= np.max(Sxx_db)
+    vmin = np.percentile(Sxx_db, low_percentile)
+    vmax = np.percentile(Sxx_db, high_percentile)
+    if vmax - vmin > max_dynamic_range:
+        vmin = vmax - max_dynamic_range
+    return Sxx_db, vmin, vmax
+
 def plot_spectrogram(f, t, Sxx, center_freq=0, title='Spectrogram', packet_start=None, sample_rate=None, signal=None):
     """מציג ספקטוגרמה עם ציר תדר ב-MHz, וגרף אות עם סימון תחילת פקטה"""
-    Sxx_db = 10 * np.log10(np.abs(Sxx) + 1e-10)
-    vmin = np.percentile(Sxx_db, 10)
-    vmax = np.percentile(Sxx_db, 99)
+    Sxx_db, vmin, vmax = normalize_spectrogram(Sxx)
 
     fig, (ax1, ax2) = plt.subplots(2, 1, figsize=(12, 8), height_ratios=[2, 1])
 

--- a/vector_analyzer/mat_analyzer.py
+++ b/vector_analyzer/mat_analyzer.py
@@ -6,6 +6,7 @@ import tkinter as tk
 from tkinter import filedialog, ttk
 import threading
 from scipy import signal as sig
+from utils import normalize_spectrogram
 
 class MatAnalyzerGUI:
     def __init__(self):
@@ -113,9 +114,8 @@ class MatAnalyzerGUI:
                                       noverlap=noverlap,
                                       return_onesided=False)
             
-            # המרה ל-dB
-            Sxx_db = 20 * np.log10(np.abs(Sxx) + 1e-12)
-            Sxx_db = Sxx_db - np.max(Sxx_db)  # נרמול למקסימום 0 dB
+            # נרמול הספקטרוגרמה
+            Sxx_db, vmin, vmax = normalize_spectrogram(Sxx)
             
             # הזזת התדרים
             f = np.fft.fftshift(f)
@@ -129,11 +129,11 @@ class MatAnalyzerGUI:
             
             # הצגת הספקטרוגרמה
             plt.figure(figsize=(12, 6))
-            plt.pcolormesh(f/1e6, t*1e3, Sxx_db.T, 
+            plt.pcolormesh(f/1e6, t*1e3, Sxx_db.T,
                           shading='gouraud',
                           cmap=default_colormap,
-                          vmin=-60,  # הגבלת טווח הצבעים
-                          vmax=0)
+                          vmin=vmin,
+                          vmax=vmax)
             plt.colorbar(label='עוצמה [dB]')
             plt.title(f"ספקטרוגרמה - {Path(self.file_path).name}")
             plt.xlabel("תדר [MHz]")

--- a/vector_analyzer/spectrogram_analysis.py
+++ b/vector_analyzer/spectrogram_analysis.py
@@ -3,6 +3,7 @@ from scipy.io import loadmat
 from scipy import signal
 import matplotlib.pyplot as plt
 from matplotlib.colors import Normalize
+from utils import normalize_spectrogram
 
 def plot_spectrum(data, sample_rate, center_freq, title):
     """ציור ספקטרום של האות"""
@@ -49,16 +50,15 @@ def create_spectrogram(data, sample_rate, center_freq, title):
     # הזזת התדרים לתדר המרכזי
     freqs = np.fft.fftshift(freqs) + center_freq
     Sxx = np.fft.fftshift(Sxx, axes=0)
-    
-    # חישוב הספקטרום בדציבלים
-    Sxx_db = 10 * np.log10(np.abs(Sxx) + 1e-10)
-    
+
+    # נרמול הספקטרוגרמה
+    Sxx_db, vmin, vmax = normalize_spectrogram(Sxx)
+
     # ציור הספקטוגרמה
     plt.figure(figsize=(15, 8))
-    plt.pcolormesh(times, (freqs - center_freq)/1e6, Sxx_db, 
+    plt.pcolormesh(times, (freqs - center_freq)/1e6, Sxx_db,
                   shading='nearest', cmap='viridis',
-                  norm=Normalize(vmin=np.percentile(Sxx_db, 10),
-                               vmax=np.percentile(Sxx_db, 99)))
+                  norm=Normalize(vmin=vmin, vmax=vmax))
     
     plt.colorbar(label='Power (dB)')
     plt.title(f'Spectrogram - {title}')


### PR DESCRIPTION
## Summary
- add `normalize_spectrogram` helper in utils and use from `plot_spectrogram`
- display normalized spectrograms when showing packets and in packet extractor
- normalize spectrogram display in MAT analyzer and spectrogram analysis scripts

## Testing
- `python -m py_compile packet_extractor.py show_packets.py utils.py vector_analyzer/mat_analyzer.py vector_analyzer/spectrogram_analysis.py`

------
https://chatgpt.com/codex/tasks/task_e_68407a899c788328ad0912b0edfb260a