### PR TITLE
Improve signal normalization

### DIFF
--- a/main.py
+++ b/main.py
@@ -11,6 +11,8 @@ from utils import (
     get_sample_rate_from_mat,
     apply_frequency_shift,
     compute_freq_ranges,
+    normalize_signal,
+    check_vector_power_uniformity,
 )
 
 MAX_PACKETS = 6
@@ -241,6 +243,9 @@ class VectorApp:
                     freq_shifts.append(cfg['freq_shift'])
                 else:
                     freq_shifts.append(0)
+
+                if self.normalize.get():
+                    y = normalize_signal(y)
                 
                 # Period in samples
                 period_samples = int(cfg['period'] * TARGET_SAMPLE_RATE)
@@ -274,6 +279,7 @@ class VectorApp:
                 max_abs = np.abs(vector).max()
                 if max_abs > 0:
                     vector = vector / max_abs
+                check_vector_power_uniformity(vector, window_size=int(0.001 * TARGET_SAMPLE_RATE))
                     
             if output_format == "wv":
                 from utils import save_vector_wv

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,6 +1,7 @@
 import os
 import sys
 import numpy as np
+import pytest
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
 
@@ -11,6 +12,8 @@ from utils import (
     create_spectrogram,
     plot_spectrogram,
     save_vector_wv,
+    normalize_signal,
+    check_vector_power_uniformity,
 )
 
 
@@ -168,5 +171,21 @@ def test_save_vector_wv(tmp_path):
     with open(out_file, "rb") as f:
         header = f.read(20)
     assert b"TYPE: SMU-WV" in header
+
+
+def test_normalize_signal_peak():
+    data = np.array([0.5, 2.0, -1.0], dtype=np.float32)
+    norm = normalize_signal(data)
+    assert np.isclose(np.max(np.abs(norm)), 1.0)
+    assert norm.dtype == np.float32
+
+
+def test_check_vector_power_uniformity():
+    vec = np.concatenate([np.ones(1000), 0.1 * np.ones(1000)]).astype(np.float32)
+    with pytest.raises(ValueError):
+        check_vector_power_uniformity(vec, window_size=100, max_db_delta=3)
+
+    vec = np.ones(2000, dtype=np.complex64)
+    check_vector_power_uniformity(vec, window_size=100, max_db_delta=3)
 
 

--- a/utils.py
+++ b/utils.py
@@ -114,6 +114,34 @@ def compute_freq_ranges(shifts, margin=1e6):
             ranges.append((start, end))
     return ranges
 
+
+def normalize_signal(sig, target_peak=1.0):
+    """Scale a signal so its peak amplitude equals ``target_peak``."""
+    max_abs = np.max(np.abs(sig))
+    if max_abs == 0:
+        dtype = np.complex64 if np.iscomplexobj(sig) else np.float32
+        return sig.astype(dtype)
+    scaled = sig / max_abs * target_peak
+    dtype = np.complex64 if np.iscomplexobj(scaled) else np.float32
+    return scaled.astype(dtype)
+
+
+def check_vector_power_uniformity(vector, window_size=1024, max_db_delta=3):
+    """Validate uniform power across ``vector`` using a sliding RMS window."""
+    if window_size <= 0 or window_size > len(vector):
+        window_size = len(vector)
+    power = np.abs(vector) ** 2
+    kernel = np.ones(window_size) / window_size
+    rms = np.sqrt(np.convolve(power, kernel, mode="valid"))
+    rms = rms[rms > 1e-12]
+    if len(rms) == 0:
+        return
+    db = 20 * np.log10(rms)
+    if db.max() - db.min() > max_db_delta:
+        raise ValueError(
+            f"Vector power variation {db.max() - db.min():.2f} dB exceeds {max_db_delta} dB"
+        )
+
 def create_spectrogram(sig, sr, center_freq=0, max_samples=1_000_000):
     """יוצר ספקטוגרמה מהאות.
 


### PR DESCRIPTION
## Summary
- normalize each packet before insertion into vector
- validate power uniformity across the final vector
- expose helpers `normalize_signal` and `check_vector_power_uniformity`
- test the new helpers

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684ed9fb82088328af6f58c1883d2da5