### PR TITLE
Improve signal normalization

### DIFF
--- a/main.py
+++ b/main.py
@@ -11,6 +11,9 @@ from utils import (
     get_sample_rate_from_mat,
     apply_frequency_shift,
     compute_freq_ranges,
+    normalize_signal,
+    check_vector_power_uniformity,
+    equalize_vector_power,
 )
 
 MAX_PACKETS = 6
@@ -241,6 +244,9 @@ class VectorApp:
                     freq_shifts.append(cfg['freq_shift'])
                 else:
                     freq_shifts.append(0)
+
+                if self.normalize.get():
+                    y = normalize_signal(y)
                 
                 # Period in samples
                 period_samples = int(cfg['period'] * TARGET_SAMPLE_RATE)
@@ -269,11 +275,17 @@ class VectorApp:
             print("Vector max:", np.abs(vector).max())
             print("Vector min:", np.abs(vector).min())
             
-            # Normalize
+            # Normalize and equalize power
             if self.normalize.get():
+                vector = equalize_vector_power(
+                    vector, window_size=int(0.001 * TARGET_SAMPLE_RATE)
+                )
                 max_abs = np.abs(vector).max()
                 if max_abs > 0:
                     vector = vector / max_abs
+                check_vector_power_uniformity(
+                    vector, window_size=int(0.001 * TARGET_SAMPLE_RATE)
+                )
                     
             if output_format == "wv":
                 from utils import save_vector_wv

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,6 +1,7 @@
 import os
 import sys
 import numpy as np
+import pytest
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
 
@@ -11,6 +12,9 @@ from utils import (
     create_spectrogram,
     plot_spectrogram,
     save_vector_wv,
+    normalize_signal,
+    check_vector_power_uniformity,
+    equalize_vector_power,
 )
 
 
@@ -168,5 +172,33 @@ def test_save_vector_wv(tmp_path):
     with open(out_file, "rb") as f:
         header = f.read(20)
     assert b"TYPE: SMU-WV" in header
+
+
+def test_normalize_signal_peak():
+    data = np.array([0.5, 2.0, -1.0], dtype=np.float32)
+    norm = normalize_signal(data)
+    assert np.isclose(np.max(np.abs(norm)), 1.0)
+    assert norm.dtype == np.float32
+
+
+def test_check_vector_power_uniformity():
+    vec = np.concatenate([np.ones(1000), 0.1 * np.ones(1000)]).astype(np.float32)
+    with pytest.raises(ValueError):
+        check_vector_power_uniformity(vec, window_size=100, max_db_delta=3)
+
+    vec = np.ones(2000, dtype=np.complex64)
+    check_vector_power_uniformity(vec, window_size=100, max_db_delta=3)
+
+
+def test_equalize_vector_power_reduces_delta():
+    vec = np.concatenate([np.ones(1000), 0.1 * np.ones(1000)]).astype(np.float32)
+    balanced = equalize_vector_power(vec, window_size=100, max_db_delta=3)
+    check_vector_power_uniformity(balanced, window_size=100, max_db_delta=3)
+    db = 20 * np.log10(
+        np.sqrt(
+            np.mean(np.abs(balanced.reshape(-1, 100)) ** 2, axis=1)
+        )
+    )
+    assert db.max() - db.min() <= 3
 
 


### PR DESCRIPTION
## Summary
- normalize each packet before insertion into vector
- validate power uniformity across the final vector
- expose helpers `normalize_signal`, `check_vector_power_uniformity`, and `equalize_vector_power`
- test the new helpers
- optimize power uniformity check to avoid blocking the GUI

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684ed9fb82088328af6f58c1883d2da5