### PR TITLE
Improve signal normalization

### DIFF
--- a/main.py
+++ b/main.py
@@ -11,6 +11,8 @@ from utils import (
     get_sample_rate_from_mat,
     apply_frequency_shift,
     compute_freq_ranges,
+    normalize_signal,
+    check_vector_power_uniformity,
 )
 
 MAX_PACKETS = 6
@@ -241,6 +243,9 @@ class VectorApp:
                     freq_shifts.append(cfg['freq_shift'])
                 else:
                     freq_shifts.append(0)
+
+                if self.normalize.get():
+                    y = normalize_signal(y)
                 
                 # Period in samples
                 period_samples = int(cfg['period'] * TARGET_SAMPLE_RATE)
@@ -274,6 +279,11 @@ class VectorApp:
                 max_abs = np.abs(vector).max()
                 if max_abs > 0:
                     vector = vector / max_abs
+                check_vector_power_uniformity(
+                    vector,
+                    window_size=int(0.001 * TARGET_SAMPLE_RATE),
+                    rectify=True,
+                )
                     
             if output_format == "wv":
                 from utils import save_vector_wv


### PR DESCRIPTION
## Summary
- normalize each packet before insertion into vector
- validate power uniformity across the final vector
- expose helpers `normalize_signal` and `check_vector_power_uniformity`
- test the new helpers
- optimize power uniformity check to avoid blocking the GUI
- fix non-uniform power automatically when detected

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684ed9fb82088328af6f58c1883d2da5